### PR TITLE
bugfix: 502 will occured when provider restart but mosn not.

### DIFF
--- a/dubbo/remoting/zookeeper/listener.go
+++ b/dubbo/remoting/zookeeper/listener.go
@@ -298,8 +298,8 @@ func (l *ZkEventListener) listenDirEvent(conf *common.URL, zkPath string, listen
 					listener.DataChange(remoting.Event{Path: zkPath, Action: remoting.EventTypeDel})
 					//remove cache. If don't do this, next node add event will not coming after provider restart.
 					l.pathMapLock.Lock()
+					defer l.pathMapLock.Unlock()
 					delete(l.pathMap, dubboPath)
-					l.pathMapLock.Unlock()
 				}
 				logger.Warnf("listenSelf(zk path{%s}) goroutine exit now", zkPath)
 			}(dubboPath, listener)

--- a/dubbo/remoting/zookeeper/listener.go
+++ b/dubbo/remoting/zookeeper/listener.go
@@ -296,6 +296,10 @@ func (l *ZkEventListener) listenDirEvent(conf *common.URL, zkPath string, listen
 			go func(zkPath string, listener remoting.DataListener) {
 				if l.listenServiceNodeEvent(zkPath) {
 					listener.DataChange(remoting.Event{Path: zkPath, Action: remoting.EventTypeDel})
+					//remove cache. If don't do this, next node add event will not coming after provider restart.
+					l.pathMapLock.Lock()
+					delete(l.pathMap, dubboPath)
+					l.pathMapLock.Unlock()
 				}
 				logger.Warnf("listenSelf(zk path{%s}) goroutine exit now", zkPath)
 			}(dubboPath, listener)


### PR DESCRIPTION
当provider只有一个节点时，provider进行restart操作：
provider关闭时，zk节点删除，consumer对应的listener退出，但pathMap未移除对应的key，导致provider重新注册到zk时，对应的event add事件无法正常向下执行，导致cluster_manager中和host 为空，502